### PR TITLE
Add API entries for next and previous answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Currently available:
   - `/auth/password/change/`
 - `/api/users/`
   - `/api/users/{ID}/`
+- `/api/offerings/{OFF_ID}/exercises/{EX_ID}/answers/{ANS_ID}/previous/` (previous answer for this user and exercise)
+- `/api/offerings/{OFF_ID}/exercises/{EX_ID}/answers/{ANS_ID}/next/` (next answer for this user and exercise)
 
 ## References
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -9,6 +9,8 @@ answers_router = routers.DefaultRouter()
 answers_router.register(r'answers', views.AnswerViewSet, basename='answers')
 
 urlpatterns = [
+    path(r'offerings/<int:off_pk>/exercises/<slug:ex_slug>/answers/<int:ans_pk>/previous/', views.get_previous_answer),
+    path(r'offerings/<int:off_pk>/exercises/<slug:ex_slug>/answers/<int:ans_pk>/next/', views.get_next_answer),
     path(r'offerings/<int:off_pk>/exercises/<slug:ex_slug>/', include(answers_router.urls)),
     path(r'offerings/<int:off_pk>/exercises/', views.ExerciseViewSet.as_view({'post': 'create',
                                                                                 'get': 'list'})),

--- a/core/views.py
+++ b/core/views.py
@@ -19,13 +19,13 @@ class UserViewSet(viewsets.ModelViewSet):
 
 class ExerciseViewSet(mixins.CreateModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = ExerciseSerializer
-    
+
     def get_permissions(self):
         permissions = [IsAdminUser]
         if self.action == 'list':
-            permissions = [IsEnrolledInOfferingOrIsStaff] 
+            permissions = [IsEnrolledInOfferingOrIsStaff]
 
-        return [permission() for permission in permissions] 
+        return [permission() for permission in permissions]
 
     def create(self, request, off_pk=None):
         offering = get_object_or_404(Offering, pk=off_pk)
@@ -75,7 +75,7 @@ class AnswerViewSet(viewsets.ModelViewSet):
             return Response(answer.data, status=status.HTTP_201_CREATED)
 
         return Response(answer.errors, status=status.HTTP_400_BAD_REQUEST)
-      
+
 
 def user_filter(request):
     user_pk = request.user.pk
@@ -87,6 +87,38 @@ def user_filter(request):
         # Can only see own summaries if not admin
         filters['user__pk'] = user_pk
     return filters
+
+
+@api_view(['GET'])
+@permission_classes([IsEnrolledInOfferingOrIsStaff])
+def get_previous_answer(request, off_pk, ex_slug, ans_pk):
+    get_object_or_404(Offering, pk=off_pk)
+
+    filters = user_filter(request)
+    try:
+        answer = Answer.objects.filter(
+            exercise__pk=ex_slug,
+            pk__lt=ans_pk,
+            **filters).latest('pk')
+    except Answer.DoesNotExist:
+        raise Http404()
+    return Response(AnswerSerializer(answer).data)
+
+
+@api_view(['GET'])
+@permission_classes([IsEnrolledInOfferingOrIsStaff])
+def get_next_answer(request, off_pk, ex_slug, ans_pk):
+    get_object_or_404(Offering, pk=off_pk)
+
+    filters = user_filter(request)
+    try:
+        answer = Answer.objects.filter(
+            exercise__pk=ex_slug,
+            pk__gt=ans_pk,
+            **filters).earliest('pk')
+    except Answer.DoesNotExist:
+        raise Http404()
+    return Response(AnswerSerializer(answer).data)
 
 
 @api_view(['GET'])


### PR DESCRIPTION
Fix #36 

New routes:
- `/api/offerings/{OFF_PK}/exercises/{EX_PK}/answers/{ANS_PK}/previous/`
- `/api/offerings/{OFF_PK}/exercises/{EX_PK}/answers/{ANS_PK}/next/`