### PR TITLE
Simplify exercise name in dashboard

### DIFF
--- a/frontend/frontend-dev/src/fragments/ExerciseResultVisualization/CodeExerciseResult/index.tsx
+++ b/frontend/frontend-dev/src/fragments/ExerciseResultVisualization/CodeExerciseResult/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import Button from "../../../components/Button";
 import Title from "../../../components/Title";
 import { useUser } from "../../../contexts/user-context";
-import { IExercise } from "../../../models/Exercise";
+import { getName, IExercise } from "../../../models/Exercise";
 import { IUserAnswerSummaryMap } from "../../../models/UserAnswerSummary";
 import { useAnswer } from "../../../services/exercises";
 import { IAnswer } from "../../../models/Answer";
@@ -33,7 +33,7 @@ const CodeExerciseResult = ({
   return (
     <>
       <Title variant={5} className="px-4 mt-2">
-        {exercise?.slug || ""}
+        {getName(exercise)}
       </Title>
       <div className="px-4 mt-4 max-w-full">
         <Button className="uppercase tracking-wide">Ver Exercício</Button>

--- a/frontend/frontend-dev/src/fragments/ExerciseResultVisualization/InstructorResultVisualization/index.tsx
+++ b/frontend/frontend-dev/src/fragments/ExerciseResultVisualization/InstructorResultVisualization/index.tsx
@@ -11,6 +11,7 @@ import Title from "../../../components/Title";
 import { MultipleChoiceAnswers } from "../InstructorMultipleChoiceExercise";
 import { CodeExerciseResult } from "../InstructorCodeExerciseResult";
 import { TextAnswersResults } from "../InstructorTextExercise";
+import { getName, IExercise } from "../../../models/Exercise";
 
 interface IExerciseAnswersParams {
   offering: number;
@@ -57,7 +58,7 @@ function UnmemoizedInstructorResultColumn({
   return (
     <Container>
       <div className="mt-4 fit-content">
-        <Title variant={5}>{slug || ""}</Title>
+        <Title variant={5}>{getName(selectedData as IExercise)}</Title>
       </div>
 
       <section className="flex flex-col w-full">

--- a/frontend/frontend-dev/src/fragments/ExerciseResultVisualization/index.tsx
+++ b/frontend/frontend-dev/src/fragments/ExerciseResultVisualization/index.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ExercisesProvider } from "../../contexts/ExercisesContext";
 import { useExerciseContext } from "../../hooks/useExerciseContext";
-import { IExerciseGroups } from "../../models/Exercise";
+import { getName, IExerciseGroups } from "../../models/Exercise";
 import Column from "./Column";
 import { InstructorResultColumn } from "./InstructorResultVisualization";
 import ResultColumn from "./ResultColumn";
@@ -55,7 +54,7 @@ const ExerciseResultVisualization = ({
     const exerciseList = contentGroups[contentGroup];
     setExercises(
       Object.keys(contentGroups) && contentGroup
-        ? exerciseList.map((exercise) => exercise.slug)
+        ? exerciseList.map(getName)
         : [],
     );
     if (exerciseList)

--- a/frontend/frontend-dev/src/models/Exercise.ts
+++ b/frontend/frontend-dev/src/models/Exercise.ts
@@ -40,3 +40,16 @@ export const groupByTopicAndContent = (
 
   return groups;
 };
+
+export const getName = (exercise: IExercise) => {
+  const slug = exercise?.slug;
+  if (!slug) return "";
+
+  const parts = slug.split("-");
+  const name = parts[parts.length - 1].split("_").join(" ");
+  if (exercise.type) {
+    return `[${exercise.type}] ${name}`;
+  } else {
+    return slug;
+  }
+};


### PR DESCRIPTION
Fix #47 

Previous version showed the exercise slug:

![image](https://user-images.githubusercontent.com/219816/142333155-855d0f33-c574-46b3-b8db-f5c6055c8d6a.png)

Proposed version extracts the name from slug and shows the exercise type:

![image](https://user-images.githubusercontent.com/219816/142333064-8d58aa05-e95a-4e2f-8e86-f8fe0ab18e6e.png)
