### PR TITLE
Adds swagger. Now the documentation is presented at /doc and /redoc

### DIFF
--- a/devlife_support/settings.py
+++ b/devlife_support/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     "django.contrib.sites",
     "rest_framework",
     "rest_framework.authtoken",
+    "drf_yasg",
     "dj_rest_auth",
     "corsheaders",
 ]

--- a/devlife_support/urls.py
+++ b/devlife_support/urls.py
@@ -16,7 +16,29 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include, re_path
 
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+schema_view = get_schema_view(
+    openapi.Info(
+        title="DevLife Support API",
+        default_version='v1',
+        description="API to manage DevLife Students path.",
+        terms_of_service="https://insper.edu.br",
+        contact=openapi.Contact(email="contato@insper.edu.br"),
+        license=openapi.License(name="Inper License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
+
 urlpatterns = [
+    re_path(r'^doc(?P<format>\.json|\.yaml)$',
+            schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    path('doc/', schema_view.with_ui('swagger', cache_timeout=0),
+         name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0),
+         name='schema-redoc'),
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
     path("api/auth/", include("dj_rest_auth.urls")),


### PR DESCRIPTION
This branch adds the swagger to the API. This makes easier testing the API on the browser or using Postman.

# Test:

- Run the API (using port 8080, for example)
- Access the for new paths:
1.     /spec.json (json spec of API doc)
2.     /spec.yaml (yaml spec of API doc)
3.     /doc (Swagger UI view of API doc)
4.     /redoc (Redoc view of API doc)

# Reference for this update:

- https://www.jasonmars.org/2020/04/22/add-swagger-to-django-rest-api-quickly-4-mins-without-hiccups/
